### PR TITLE
Add x install as an installation method for ddv

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ $ cargo install --locked ddv
 $ brew install lusingander/tap/ddv
 ```
 
+### [X-CMD](https://x-cmd.com/)
+
+```
+$ x install ddv
+```
+
 ### Downloading binary
 
 You can download pre-compiled binaries from [releases](https://github.com/lusingander/ddv/releases).


### PR DESCRIPTION
Hi, ddv community! 👋

I've added `x install ddv` to the x-cmd ecosystem, making it easier for users to install ddv across different platforms (Linux, macOS, Windows) without manually searching for installation methods. `x install` automatically detects the appropriate installation command for the user's system and provides an interactive selection interface, improving the overall installation experience.

Additionally, I've written an [article introducing ddv](https://x-cmd.com/install/ddv) in the x-cmd community.

This PR simply updates the README.md to include `x install` as a recommended installation method. I hope this helps more users get started with ddv quickly! 🚀

Thank you for your time and for building such an excellent project! Let me know if you have any questions or need further details.
