### PR TITLE
Fix panic on secondary index Options None unwrap

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -230,9 +230,9 @@ impl From<AwsLocalSecondaryIndexDescription> for LocalSecondaryIndexDescription 
         let index_name = value.index_name.unwrap();
         let key_schema = to_key_schema(value.key_schema.unwrap());
         let projection = value.projection.unwrap().into();
-        let index_size_bytes = value.index_size_bytes.unwrap() as u64;
-        let item_count = value.item_count.unwrap() as u64;
-        let index_arn = value.index_arn.unwrap();
+        let index_size_bytes = value.index_size_bytes.unwrap_or(0) as u64;
+        let item_count = value.item_count.unwrap_or(0) as u64;
+        let index_arn = value.index_arn.unwrap_or("".to_string());
         LocalSecondaryIndexDescription {
             index_name,
             key_schema,


### PR DESCRIPTION
Backtrace:
```
thread 'tokio-runtime-worker' panicked at src/client.rs:233:55:
called `Option::unwrap()` on a `None` value
stack backtrace:
   0: rust_begin_unwind
   1: core::panicking::panic_fmt
   2: core::panicking::panic
   3: core::option::unwrap_failed
   4: ddv::client::<impl core::convert::From<aws_sdk_dynamodb::types::_local_secondary_index_description::LocalSecondaryIndexDescription> for ddv::data::LocalSecondaryIndexDescription>::from
   5: alloc::vec::in_place_collect::from_iter_in_place
   6: ddv::client::to_table_description
   7: ddv::app::App::load_table_description::{{closure}}
   8: tokio::runtime::task::raw::poll
   9: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
  10: tokio::runtime::scheduler::multi_thread::worker::Context::run
  11: tokio::runtime::context::runtime::enter_runtime
  12: tokio::runtime::scheduler::multi_thread::worker::run
  13: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
  14: tokio::runtime::task::core::Core<T,S>::poll
  15: tokio::runtime::task::harness::Harness<T,S>::poll
  16: tokio::runtime::blocking::pool::Inner::run
```

Table which error occur can be created locally (don't know if happens on AWS) with:
```sh
aws dynamodb create-table \
  --table-name test1 \
  --endpoint-url http://localhost:8000 \
  --attribute-definitions \
      AttributeName=c_id,AttributeType=N \
      AttributeName=main_id,AttributeType=S \
      AttributeName=main_number,AttributeType=S \
  --key-schema \
      AttributeName=c_id,KeyType=HASH \
      AttributeName=main_id,KeyType=RANGE \
  --local-secondary-indexes '[
      {
        "IndexName": "main_number",
        "KeySchema": [
          {"AttributeName": "c_id", "KeyType": "HASH"},
          {"AttributeName": "main_number", "KeyType": "RANGE"}
        ],
        "Projection": {"ProjectionType": "ALL"}
      }
    ]' \
  --billing-mode PAY_PER_REQUEST
```